### PR TITLE
Fix a routing bug

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,7 +52,7 @@ impl State {
                 .trim_end_matches("/")
                 .to_string();
             let mut prefix = path.clone();
-            if prefix.len() > 0 {
+            if !prefix.is_empty() {
                 prefix.insert(0, '/');
             }
             prefix.push_str("/{*p}");

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,7 +52,9 @@ impl State {
                 .trim_end_matches("/")
                 .to_string();
             let mut prefix = path.clone();
-            prefix.insert(0, '/');
+            if prefix.len() > 0 {
+                prefix.insert(0, '/');
+            }
             prefix.push_str("/{*p}");
             let fallback_path = p.fallback_path.clone().map_or("".to_string(), |v| v);
             let success_even_no_content = p.success_even_no_content.is_some_and(|v| v);


### PR DESCRIPTION
This bug can be reproduced when we specify the provider as follows:

```json
  "providers": [
    {
      "path": "/",
      "src": "s3://my-bucket"
    }
  ]
```