### PR TITLE
fix: lack of shared libraries in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,12 @@ RUN set -eux; \
 # https://github.com/GoogleContainerTools/distroless
 # https://console.cloud.google.com/gcr/images/distroless/GLOBAL
 FROM gcr.io/distroless/cc-debian12:nonroot-amd64
-COPY --from=apps /usr/src/app/target/container/fanlin-rs /usr/local/bin/fanlin-rs
-COPY --from=apps /usr/src/app/profiles/default.icc       /var/lib/fanlin-rs/
-COPY --from=deps /usr/local/lib/libjemalloc.so.2         /lib/x86_64-linux-gnu/
-COPY --from=deps /lib/x86_64-linux-gnu/liblcms2.so.*     /lib/x86_64-linux-gnu/
-COPY --from=deps /lib/x86_64-linux-gnu/libm.so.*         /lib/x86_64-linux-gnu/
+COPY --from=apps --chmod=755 /usr/src/app/target/container/fanlin-rs /usr/local/bin/fanlin-rs
+COPY --from=apps --chmod=644 /usr/src/app/profiles/default.icc       /var/lib/fanlin/
+COPY --from=deps --chmod=644 /usr/local/lib/libjemalloc.so.2         /lib/x86_64-linux-gnu/
+COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/liblcms2.so.*     /lib/x86_64-linux-gnu/
+COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/libssl.so.*       /lib/x86_64-linux-gnu/
+COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/libcrypto.so.*    /lib/x86_64-linux-gnu/
 ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENTRYPOINT ["/usr/local/bin/fanlin-rs"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,12 @@ RUN set -eux; \
 # https://github.com/GoogleContainerTools/distroless
 # https://console.cloud.google.com/gcr/images/distroless/GLOBAL
 FROM gcr.io/distroless/cc-debian12:nonroot-amd64
-COPY --from=apps --chmod=755 /usr/src/app/target/container/fanlin-rs /usr/local/bin/fanlin-rs
+COPY --from=apps --chmod=755 /usr/src/app/target/container/fanlin-rs /usr/local/bin/fanlin
 COPY --from=apps --chmod=644 /usr/src/app/profiles/default.icc       /var/lib/fanlin/
 COPY --from=deps --chmod=644 /usr/local/lib/libjemalloc.so.2         /lib/x86_64-linux-gnu/
 COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/liblcms2.so.*     /lib/x86_64-linux-gnu/
 COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/libssl.so.*       /lib/x86_64-linux-gnu/
 COPY --from=deps --chmod=644 /lib/x86_64-linux-gnu/libcrypto.so.*    /lib/x86_64-linux-gnu/
 ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENTRYPOINT ["/usr/local/bin/fanlin-rs"]
+ENTRYPOINT ["/usr/local/bin/fanlin"]
 CMD ["--help"]

--- a/fanlin-container.json
+++ b/fanlin-container.json
@@ -2,7 +2,7 @@
   "port": 3000,
   "bind_addr": "0.0.0.0",
   "max_clients": 50,
-  "profile_path": "/var/lib/fanlin-rs/default.icc",
+  "profile_path": "/var/lib/fanlin/default.icc",
   "client": {
     "s3": {
       "aws_region": "ap-northeast-1",


### PR DESCRIPTION
```
/ # ls -la /lib/x86_64-linux-gnu/
total 10828
drwxr-xr-x    1 root     root          4096 Mar 15 02:28 .
drwxr-xr-x    1 root     root          4096 Jan  8  2023 ..
-rwxr-xr-x    1 root     root        210904 Nov  1 12:42 ld-linux-x86-64.so.2
-rw-r--r--    1 root     root         14640 Nov  1 12:42 libBrokenLocale.so.1
-rw-r--r--    1 root     root         14480 Nov  1 12:42 libanl.so.1
-rwxr-xr-x    1 root     root       1922136 Nov  1 12:42 libc.so.6
-rw-r--r--    1 root     root         50200 Nov  1 12:42 libc_malloc_debug.so.0
-rw-r--r--    1 root     root         14480 Nov  1 12:42 libdl.so.2
-rw-r--r--    1 root     root        125312 Jan  8  2023 libgcc_s.so.1
-rwxr-xr-x    1 root     root       5592760 Mar 15 02:28 libjemalloc.so.2
-rw-r--r--    1 root     root        398304 Feb 19  2023 liblcms2.so.2
-rw-r--r--    1 root     root        398304 Feb 19  2023 liblcms2.so.2.0.14
-rw-r--r--    1 root     root        907784 Nov  1 12:42 libm.so.6
-rw-r--r--    1 root     root         18880 Nov  1 12:42 libmemusage.so
-rw-r--r--    1 root     root       1019408 Nov  1 12:42 libmvec.so.1
-rw-r--r--    1 root     root         93248 Nov  1 12:42 libnsl.so.1
-rw-r--r--    1 root     root         39896 Nov  1 12:42 libnss_compat.so.2
-rw-r--r--    1 root     root         14400 Nov  1 12:42 libnss_dns.so.2
-rw-r--r--    1 root     root         14400 Nov  1 12:42 libnss_files.so.2
-rw-r--r--    1 root     root         27136 Nov  1 12:42 libnss_hesiod.so.2
-rw-r--r--    1 root     root         14592 Nov  1 12:42 libpcprofile.so
-rw-r--r--    1 root     root         14480 Nov  1 12:42 libpthread.so.0
-rw-r--r--    1 root     root         60328 Nov  1 12:42 libresolv.so.2
-rw-r--r--    1 root     root         14640 Nov  1 12:42 librt.so.1
-rw-r--r--    1 root     root         35752 Nov  1 12:42 libthread_db.so.1
-rw-r--r--    1 root     root         14480 Nov  1 12:42 libutil.so.1
```

```
$ ldd target/release/fanlin-rs
        linux-vdso.so.1 (0x00007ffda3328000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f6d48f92000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f6d48a7f000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6d48a51000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6d48968000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6d48756000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6d4aa81000)
```