### PR TITLE
fix: make embedded icc profile utilization optional because of the performance issue, the creation of a transform object takes 40ms

### DIFF
--- a/fanlin-container.json
+++ b/fanlin-container.json
@@ -3,6 +3,7 @@
   "bind_addr": "0.0.0.0",
   "max_clients": 50,
   "profile_path": "/var/lib/fanlin/default.icc",
+  "use_embedded_profile": true,
   "client": {
     "s3": {
       "aws_region": "ap-northeast-1",

--- a/fanlin.json
+++ b/fanlin.json
@@ -4,6 +4,7 @@
   "max_clients": 50,
   "fallback_path": "/baz/no_img.jpg",
   "profile_path": "profiles/default.icc",
+  "use_embedded_profile": true,
   "client": {
     "s3": {
       "aws_region": "ap-northeast-1",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub max_clients: usize,
     pub fallback_path: Option<String>,
     pub profile_path: Option<String>,
+    pub use_embedded_profile: Option<bool>,
     pub suppress_logging: Option<bool>,
     pub client: Client,
     pub providers: Vec<Provider>,
@@ -65,6 +66,7 @@ fn test_legit_config() {
           "max_clients": 1024,
           "fallback_path": "/foo/no_img.jpg",
           "profile_path": "/bar/default.icc",
+          "use_embedded_profile": true,
           "client": {
             "s3": {
               "aws_region": "ap-northeast-1",
@@ -96,6 +98,7 @@ fn test_legit_config() {
     assert_eq!(got.max_clients, 1024);
     assert_eq!(got.fallback_path, Some("/foo/no_img.jpg".to_string()));
     assert_eq!(got.profile_path, Some("/bar/default.icc".to_string()));
+    assert_eq!(got.use_embedded_profile, Some(true));
     assert_eq!(got.client.s3.aws_region, "ap-northeast-1".to_string());
     assert_eq!(
         got.client.s3.aws_endpoint_url,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -396,6 +396,9 @@ impl State {
     }
 
     fn convert_jpeg_color_if_needed(&self, original: &[u8]) -> Option<(u32, u32, Vec<u8>)> {
+        if !self.use_embedded_profile && self.cmyk2rgb.is_none() {
+            return None;
+        }
         // https://docs.rs/zune-jpeg/latest/zune_jpeg/struct.JpegDecoder.html
         let mut decoder = zune_jpeg::JpegDecoder::new(original);
         decoder.decode_headers().ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,12 @@ async fn main() {
             |_| {},
         );
     if let Some(path) = cfg.profile_path {
-        state.load_icc_profile(path).await;
+        state.create_cmyk_to_rgb_converter(path).await;
+    }
+    if let Some(flag) = cfg.use_embedded_profile {
+        if flag {
+            state.enable_embedded_profile_utilization();
+        }
     }
     // https://github.com/tower-rs/tower-http/blob/main/examples/axum-key-value-store/src/main.rs
     // https://docs.rs/axum/latest/axum/middleware/index.html


### PR DESCRIPTION
40ms is too slow for us.