### PR TITLE
Decrease unnecessary copy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,10 +216,10 @@ fn try_create_header(
     timer: Option<simple_server_timing_header::Timer>,
 ) -> Result<header::HeaderMap, Box<dyn std::error::Error>> {
     let mut headers = header::HeaderMap::new();
-    let content_type = header::HeaderValue::from_str(content_type)?;
+    let content_type = header::HeaderValue::from_static(content_type);
     headers.try_insert(header::CONTENT_TYPE, content_type)?;
     if params.use_webp() || params.use_avif() {
-        let vary = header::HeaderValue::from_str(VARY_ACCEPT)?;
+        let vary = header::HeaderValue::from_static(VARY_ACCEPT);
         headers.try_insert(header::VARY, vary)?;
     }
     if let Some(timer) = timer {


### PR DESCRIPTION
With `header::HeaderValue::from_static`, we can decrease unnecessary copies of String.

https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.from_static

> Convert a static string to a HeaderValue.
> This function will not perform any copying, however the string is checked to ensure that no invalid characters are present.