### PR TITLE
ci: set RUST_BACKTRACE on

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,5 +57,7 @@ jobs:
       run: docker compose --progress quiet up -d
     - name: Run test
       run: cargo test
+      env:
+        RUST_BACKTRACE: '1'
     - name: Stop containers
       run: docker compose --progress quiet down || true


### PR DESCRIPTION
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

* #103